### PR TITLE
Try to fix dimension reduction error that comes out from using sparse matrix in SCE

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -31,4 +31,4 @@ importFrom(irlba, irlba, prcomp_irlba)
 importFrom(Matrix, readMM)
 importFrom(SingleCellExperiment, rowData, SingleCellExperiment)
 importFrom(ggrepel, geom_label_repel)
-
+importFrom(Matrix, t)

--- a/R/hippo.R
+++ b/R/hippo.R
@@ -490,12 +490,17 @@ hippo_dimension_reduction = function(sce, method = c("umap", "tsne"),
   hippo_object = sce@int_metadata$hippo
   dflist = list()
   K = ncol(hippo_object$labelmatrix)
+
+  # Convert into matrix type
+  log_mtx_t = log(t(hippo_object$X[hippo_object$features[[1]]$gene,]) + 1)
+  if (!is.matrix(log_mtx_t)){
+    log_mtx_t = as.matrix(log_mtx_t)
+  }
+
   if (method == "umap"){
-    dimred = umap::umap(log(t(hippo_object$X[hippo_object$features[[1]]$gene,
-                                             ]) + 1))$layout
+    dimred = umap::umap(log_mtx_t)$layout
   }else{
-    dimred = tsne = Rtsne::Rtsne(log(t(hippo_object$X[hippo_object$features[[1]]$gene,
-                                                      ]) + 1), perplexity = perplexity,
+    dimred = tsne = Rtsne::Rtsne(log_mtx_t, perplexity = perplexity,
                                  check_duplicates = FALSE)$Y
   }
   dimred = as.data.frame(dimred)

--- a/R/hippo.R
+++ b/R/hippo.R
@@ -492,9 +492,12 @@ hippo_dimension_reduction = function(sce, method = c("umap", "tsne"),
   K = ncol(hippo_object$labelmatrix)
 
   # Convert into matrix type
-  log_mtx_t = log(t(hippo_object$X[hippo_object$features[[1]]$gene,]) + 1)
-  if (!is.matrix(log_mtx_t)){
+  mtx = hippo_object$X[hippo_object$features[[1]]$gene,]
+  if (is(mtx, 'Matrix')){
+    log_mtx_t = log(Matrix::t(mtx) +1)
     log_mtx_t = as.matrix(log_mtx_t)
+  } else {
+    log_mtx_t = log(t(mtx) +1)
   }
 
   if (method == "umap"){


### PR DESCRIPTION
Hey, 

I came to HIPPO from biorxv and tried using it on SCE with sparse count matrix. I was able to still run hippo() itself, but got an error using hippo_dimension_reduction(). 
I have added a few lines of code on the hippo_dimension_reduction() function to fix this. I don't know if HIPPO is not intended for sparse matrix at all. So feel free to reject this commit if this is the case.

Btw, I really like the HIPPO method itself. 
